### PR TITLE
refactor: rename to TS PDK template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Extism JS PDK Plugin
+# Extism TS PDK Plugin
 
 See more documentation at https://github.com/extism/js-pdk and
 [join us on Discord](https://extism.org/discord) for more help.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "main": "src/index.ts",
     "scripts": {
-      "build": "node esbuild.js && extism-js dist/index.js -i src/index.d.ts -o plugin.wasm"
+      "build": "node esbuild.js && extism-js dist/index.js -i src/index.d.ts -o dist/plugin.wasm"
     },
     "keywords": [],
     "author": "",


### PR DESCRIPTION
1. Changes the name to TS PDK Template
2. Puts the wasm file in `dist/plugin.wasm` by default